### PR TITLE
do not copy authorship pallet state

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ const progressBar = new cliProgress.SingleBar({}, cliProgress.Presets.shades_cla
  * e.g. console.log(xxhashAsHex('System', 128)).
  */
 let prefixes = ['0x26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9' /* System.Account */];
-const skippedModulesPrefix = ['System', 'Session', 'Babe', 'Grandpa', 'GrandpaFinality', 'FinalityTracker'];
+const skippedModulesPrefix = ['System', 'Session', 'Babe', 'Grandpa', 'GrandpaFinality', 'FinalityTracker', 'Authorship'];
 
 async function main() {
   if (!fs.existsSync(binaryPath)) {
@@ -133,8 +133,8 @@ async function fetchChunks(prefix, levelsRemaining, stream) {
   if (levelsRemaining <= 0) {
     const pairs = await provider.send('state_getPairs', [prefix]);
     if (pairs.length > 0) {
-      separator?stream.write(","):separator = true;
-      stream.write(JSON.stringify(pairs).slice(1,-1));
+      separator ? stream.write(",") : separator = true;
+      stream.write(JSON.stringify(pairs).slice(1, -1));
     }
     progressBar.update(++chunksFetched);
     return;
@@ -144,12 +144,12 @@ async function fetchChunks(prefix, levelsRemaining, stream) {
   if (process.env.QUICK_MODE && levelsRemaining == 1) {
     let promises = [];
     for (let i = 0; i < 256; i++) {
-      promises.push(fetchChunks(prefix + i.toString(16).padStart(2*chunksLevel, "0"), levelsRemaining - 1, stream));
+      promises.push(fetchChunks(prefix + i.toString(16).padStart(2 * chunksLevel, "0"), levelsRemaining - 1, stream));
     }
     await Promise.all(promises);
   } else {
     for (let i = 0; i < 256; i++) {
-      await fetchChunks(prefix + i.toString(16).padStart(2*chunksLevel, "0"), levelsRemaining - 1, stream);
+      await fetchChunks(prefix + i.toString(16).padStart(2 * chunksLevel, "0"), levelsRemaining - 1, stream);
     }
   }
 }


### PR DESCRIPTION
Substrate's `Authorship` pallet is in charge of identifying the current block author and also tracks block uncles. In addition to that, it also tries to purge past uncles based on the current block number.

If we do not purge this state, the purging code from the pallet may misbehave, potential border effects includes trying to allocate more memory than allowed which thus crashes the node.
